### PR TITLE
Restructure Page subclasses to include descriptive API fields

### DIFF
--- a/pages/migrations/0007_auto_20151216_1150.py
+++ b/pages/migrations/0007_auto_20151216_1150.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0020_add_index_on_page_first_published_at'),
+        ('wagtailsearchpromotions', '0001_initial'),
+        ('wagtailforms', '0002_add_verbose_names'),
+        ('wagtailredirects', '0004_set_unique_on_path_and_site'),
+        ('pages', '0006_auto_20151210_1407'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='standardpage',
+            name='page_ptr',
+        ),
+        migrations.AlterModelOptions(
+            name='homepage',
+            options={'verbose_name': 'Home Page'},
+        ),
+        migrations.RemoveField(
+            model_name='homepage',
+            name='body',
+        ),
+        migrations.DeleteModel(
+            name='StandardPage',
+        ),
+    ]

--- a/pages/migrations/0008_homepage_intro_image.py
+++ b/pages/migrations/0008_homepage_intro_image.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0008_image_created_at_index'),
+        ('pages', '0007_auto_20151216_1150'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='homepage',
+            name='intro_image',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='wagtailimages.Image', related_name='+', blank=True),
+        ),
+    ]

--- a/pages/migrations/0009_homepage_page_header.py
+++ b/pages/migrations/0009_homepage_page_header.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0008_homepage_intro_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='homepage',
+            name='page_header',
+            field=models.CharField(max_length=255, default='test'),
+            preserve_default=False,
+        ),
+    ]

--- a/pages/migrations/0010_homepage_introduction.py
+++ b/pages/migrations/0010_homepage_introduction.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0009_homepage_page_header'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='homepage',
+            name='introduction',
+            field=wagtail.wagtailcore.fields.RichTextField(default=''),
+            preserve_default=False,
+        ),
+    ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -119,9 +119,9 @@ class RelatedLink(LinkFields):
 
     class Meta:
         abstract = True
-        
-# Home Page
 
+       
+# Home Page
 class HomePageCarouselItem(Orderable, CarouselItem):
     page = ParentalKey('pages.HomePage', related_name='carousel_items')
 
@@ -131,30 +131,26 @@ class HomePageRelatedLink(Orderable, RelatedLink):
 
 
 class HomePage(Page):
-    body = StreamField(CommonStreamBlock())
-    search_fields = Page.search_fields + (
-        index.SearchField('body'),
+    page_header = models.CharField(max_length=255)
+    introduction = RichTextField()
+    intro_image = models.ForeignKey(
+        'wagtailimages.Image',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='+'
     )
     
-    api_fields = ('body', 'carousel_items', 'related_links')
+    api_fields = ('page_header', 'introduction', 'intro_image')
 
     class Meta:
-        verbose_name = "Website Page"
+        verbose_name = "Home Page"
 
 HomePage.content_panels = [
     FieldPanel('title', classname="full title"),
-    StreamFieldPanel('body'),
+    FieldPanel('page_header'),
+    ImageChooserPanel('intro_image'),
+    FieldPanel('introduction'),
     InlinePanel('carousel_items', label="Carousel items"),
     InlinePanel('related_links', label="Related links"),
-]
-    
-class StandardPage(Page):
-    body = RichTextField()
-    
-    api_fields = ('body', )
-    
-    
-StandardPage.content_panels = [
-    FieldPanel('title', classname="full title"),
-    FieldPanel('body', classname="full"),
 ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -2,18 +2,17 @@ from django.db import models
 from django import forms
 
 from wagtail.wagtailcore.models import Page, Orderable
-from wagtail.wagtailcore.fields import RichTextField, StreamField
+from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import (FieldPanel,
                                                 InlinePanel,
                                                 MultiFieldPanel,
-                                                PageChooserPanel,
-                                                StreamFieldPanel)
+                                                PageChooserPanel)
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
 from wagtail.wagtailsnippets.models import register_snippet
 from wagtail.wagtailsearch import index
 
-from wagtail.wagtailcore.blocks import TextBlock, ChooserBlock, StructBlock, ListBlock, StreamBlock, FieldBlock, CharBlock, RichTextBlock, PageChooserBlock, RawHTMLBlock
+from wagtail.wagtailcore.blocks import TextBlock, ChooserBlock, StructBlock, ListBlock, FieldBlock, CharBlock, RichTextBlock, PageChooserBlock, RawHTMLBlock
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 
@@ -39,18 +38,6 @@ class AlignedHTMLBlock(StructBlock):
 
     class Meta:
         icon = "code"
-
-
-class CommonStreamBlock(StreamBlock):
-    h2 = CharBlock(icon="title", classname="title")
-    h3 = CharBlock(icon="title", classname="title")
-    h4 = CharBlock(icon="title", classname="title")
-    intro = RichTextBlock(icon="pilcrow")
-    paragraph = RichTextBlock(icon="pilcrow")
-    aligned_image = ImageBlock(icon="image", label="Aligned image")
-    aligned_html = AlignedHTMLBlock(icon="code", label='Raw HTML')
-    document = DocumentChooserBlock(icon="doc-full-inverse")
-    page = PageChooserBlock(icon="doc-full-inverse", label="Internal Link")
 
 
 class LinkFields(models.Model):
@@ -120,7 +107,7 @@ class RelatedLink(LinkFields):
     class Meta:
         abstract = True
 
-       
+
 # Home Page
 class HomePageCarouselItem(Orderable, CarouselItem):
     page = ParentalKey('pages.HomePage', related_name='carousel_items')


### PR DESCRIPTION
This should help dictate how future pages will be created (one per common template - not necessarily one per template delivered). We want to keep all pages code here, and keep this model as DRY as possible in my opinion.