### PR TITLE
Image api v0

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailimages.tests.utils import Image, get_test_image_file
+
+
+class ImageAPI(TestCase, WagtailTestUtils):
+
+    def setUp(self):
+        self.login()
+
+    def test_api_v0_no_images(self):
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list, list)
+        self.assertEqual(response_list, [])
+
+    def test_api_v1_no_images(self):
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'], 0)
+        self.assertEqual(response_dict['images'], [])
+
+    def test_api_v0_single_image(self):
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list, list)
+        self.assertEqual(response_list, [])
+
+        expected_title = "Test image"
+        image = Image.objects.create(
+            title=expected_title,
+            file=get_test_image_file(),
+        )
+
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list, list)
+        returned_title = response_list[0]['title']
+        self.assertEqual(expected_title, returned_title)
+        returned_file_url = response_list[0]['file']
+        expected_file_name = image.file.name
+        self.assertIn(expected_file_name, returned_file_url)
+
+    def test_api_v1_single_image(self):
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'], 0)
+        self.assertEqual(response_dict['images'], [])
+
+        expected_title = "Test image"
+        image = Image.objects.create(
+            title=expected_title,
+            file=get_test_image_file(),
+        )
+
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'], 1)
+        returned_title = response_dict['images'][0]['title']
+        self.assertEqual(expected_title, returned_title)
+
+

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,33 @@
+from django.conf.urls import include, url
+
+from wagtail.wagtailimages.models import Image
+from rest_framework import routers, serializers, viewsets
+from django.views.generic.base import RedirectView
+
+
+class ImageSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Image
+        fields = ('id',
+                  'file',
+                  'title',
+                  'height',
+                  'width',
+                  'created_at',
+                  #'url',
+                  )
+
+
+class ImageViewSet(viewsets.ModelViewSet):
+    queryset = Image.objects.all()
+    serializer_class = ImageSerializer
+
+
+router = routers.DefaultRouter()
+router.register(r'', ImageViewSet)
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]
+

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -9,8 +9,37 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.contrib.wagtailapi import urls as wagtailapi_urls
 
+from wagtail.wagtailimages.models import Image
+from rest_framework import routers, serializers, viewsets
+from django.views.generic.base import RedirectView
+
+# Serializers define the API representation.
+class ImageSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Image
+        fields = ('id',
+                  'file',
+                  'title',
+                  'height',
+                  'width',
+                  'created_at',
+                  #'url',
+        )
+        
+
+# ViewSets define the view behavior.
+class ImageViewSet(viewsets.ModelViewSet):
+    queryset = Image.objects.all()
+    serializer_class = ImageSerializer
+
+# Routers provide an easy way of automatically determining the URL conf.
+router = routers.DefaultRouter()
+router.register(r'/images', ImageViewSet)
+
 
 urlpatterns = [
+
+
     url(r'^django-admin/', include(admin.site.urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
@@ -18,6 +47,7 @@ urlpatterns = [
     url(r'^images/', include(wagtailimages_urls)),
 
     url(r'^api/', include(wagtailapi_urls)),
+    url(r'^api/v0', include(router.urls)),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -14,7 +14,10 @@ from rest_framework import routers, serializers, viewsets
 from django.views.generic.base import RedirectView
 
 # Serializers define the API representation.
+
+
 class ImageSerializer(serializers.HyperlinkedModelSerializer):
+
     class Meta:
         model = Image
         fields = ('id',
@@ -24,8 +27,8 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer):
                   'width',
                   'created_at',
                   #'url',
-        )
-        
+                  )
+
 
 # ViewSets define the view behavior.
 class ImageViewSet(viewsets.ModelViewSet):

--- a/openstax/urls.py
+++ b/openstax/urls.py
@@ -9,40 +9,9 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.contrib.wagtailapi import urls as wagtailapi_urls
 
-from wagtail.wagtailimages.models import Image
-from rest_framework import routers, serializers, viewsets
-from django.views.generic.base import RedirectView
-
-# Serializers define the API representation.
-
-
-class ImageSerializer(serializers.HyperlinkedModelSerializer):
-
-    class Meta:
-        model = Image
-        fields = ('id',
-                  'file',
-                  'title',
-                  'height',
-                  'width',
-                  'created_at',
-                  #'url',
-                  )
-
-
-# ViewSets define the view behavior.
-class ImageViewSet(viewsets.ModelViewSet):
-    queryset = Image.objects.all()
-    serializer_class = ImageSerializer
-
-# Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-router.register(r'/images', ImageViewSet)
-
+from api import urls as image_api_urls_v0
 
 urlpatterns = [
-
-
     url(r'^django-admin/', include(admin.site.urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
@@ -50,7 +19,7 @@ urlpatterns = [
     url(r'^images/', include(wagtailimages_urls)),
 
     url(r'^api/', include(wagtailapi_urls)),
-    url(r'^api/v0', include(router.urls)),
+    url(r'^api/v0/images', include(image_api_urls_v0)),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism

--- a/pages/tests/tests.py
+++ b/pages/tests/tests.py
@@ -12,7 +12,9 @@ class TestPages(TestCase, WagtailTestUtils):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
 
+
 class ImageAPI(TestCase, WagtailTestUtils):
+
     def setUp(self):
         self.login()
 
@@ -20,23 +22,23 @@ class ImageAPI(TestCase, WagtailTestUtils):
         response = self.client.get('/api/v0/images/')
         self.assertEqual(response.status_code, 200)
         response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list,list)
-        self.assertEqual(response_list,[])
+        self.assertIsInstance(response_list, list)
+        self.assertEqual(response_list, [])
 
     def test_api_v1_no_images(self):
         response = self.client.get('/api/v1/images/')
         self.assertEqual(response.status_code, 200)
         response_dict = eval(response.content.decode(response.charset))
         self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'],0)
-        self.assertEqual(response_dict['images'],[])
+        self.assertEqual(response_dict['meta']['total_count'], 0)
+        self.assertEqual(response_dict['images'], [])
 
     def test_api_v0_single_image(self):
         response = self.client.get('/api/v0/images/')
         self.assertEqual(response.status_code, 200)
         response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list,list)
-        self.assertEqual(response_list,[])
+        self.assertIsInstance(response_list, list)
+        self.assertEqual(response_list, [])
 
         expected_title = "Test image"
         image = Image.objects.create(
@@ -47,20 +49,20 @@ class ImageAPI(TestCase, WagtailTestUtils):
         response = self.client.get('/api/v0/images/')
         self.assertEqual(response.status_code, 200)
         response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list,list)
+        self.assertIsInstance(response_list, list)
         returned_title = response_list[0]['title']
-        self.assertEqual(expected_title,returned_title)
+        self.assertEqual(expected_title, returned_title)
         returned_file_url = response_list[0]['file']
         expected_file_name = image.file.name
-        self.assertIn(expected_file_name,returned_file_url)
+        self.assertIn(expected_file_name, returned_file_url)
 
     def test_api_v1_single_image(self):
         response = self.client.get('/api/v1/images/')
         self.assertEqual(response.status_code, 200)
         response_dict = eval(response.content.decode(response.charset))
         self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'],0)
-        self.assertEqual(response_dict['images'],[])
+        self.assertEqual(response_dict['meta']['total_count'], 0)
+        self.assertEqual(response_dict['images'], [])
 
         expected_title = "Test image"
         image = Image.objects.create(
@@ -72,10 +74,10 @@ class ImageAPI(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         response_dict = eval(response.content.decode(response.charset))
         self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'],1)
+        self.assertEqual(response_dict['meta']['total_count'], 1)
         returned_title = response_dict['images'][0]['title']
-        self.assertEqual(expected_title,returned_title)
-       
+        self.assertEqual(expected_title, returned_title)
+
 
 class AdminPages(TestCase, WagtailTestUtils):
 

--- a/pages/tests/tests.py
+++ b/pages/tests/tests.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.wagtailimages.tests.utils import Image, get_test_image_file
 
 
 class TestPages(TestCase, WagtailTestUtils):
@@ -11,72 +10,6 @@ class TestPages(TestCase, WagtailTestUtils):
     def test_homepage_return_correct_page(self):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
-
-
-class ImageAPI(TestCase, WagtailTestUtils):
-
-    def setUp(self):
-        self.login()
-
-    def test_api_v0_no_images(self):
-        response = self.client.get('/api/v0/images/')
-        self.assertEqual(response.status_code, 200)
-        response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list, list)
-        self.assertEqual(response_list, [])
-
-    def test_api_v1_no_images(self):
-        response = self.client.get('/api/v1/images/')
-        self.assertEqual(response.status_code, 200)
-        response_dict = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'], 0)
-        self.assertEqual(response_dict['images'], [])
-
-    def test_api_v0_single_image(self):
-        response = self.client.get('/api/v0/images/')
-        self.assertEqual(response.status_code, 200)
-        response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list, list)
-        self.assertEqual(response_list, [])
-
-        expected_title = "Test image"
-        image = Image.objects.create(
-            title=expected_title,
-            file=get_test_image_file(),
-        )
-
-        response = self.client.get('/api/v0/images/')
-        self.assertEqual(response.status_code, 200)
-        response_list = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_list, list)
-        returned_title = response_list[0]['title']
-        self.assertEqual(expected_title, returned_title)
-        returned_file_url = response_list[0]['file']
-        expected_file_name = image.file.name
-        self.assertIn(expected_file_name, returned_file_url)
-
-    def test_api_v1_single_image(self):
-        response = self.client.get('/api/v1/images/')
-        self.assertEqual(response.status_code, 200)
-        response_dict = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'], 0)
-        self.assertEqual(response_dict['images'], [])
-
-        expected_title = "Test image"
-        image = Image.objects.create(
-            title=expected_title,
-            file=get_test_image_file(),
-        )
-
-        response = self.client.get('/api/v1/images/')
-        self.assertEqual(response.status_code, 200)
-        response_dict = eval(response.content.decode(response.charset))
-        self.assertIsInstance(response_dict, dict)
-        self.assertEqual(response_dict['meta']['total_count'], 1)
-        returned_title = response_dict['images'][0]['title']
-        self.assertEqual(expected_title, returned_title)
 
 
 class AdminPages(TestCase, WagtailTestUtils):

--- a/pages/tests/tests.py
+++ b/pages/tests/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailimages.tests.utils import Image, get_test_image_file
 
 
 class TestPages(TestCase, WagtailTestUtils):
@@ -11,6 +12,70 @@ class TestPages(TestCase, WagtailTestUtils):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
 
+class ImageAPI(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+    def test_api_v0_no_images(self):
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list,list)
+        self.assertEqual(response_list,[])
+
+    def test_api_v1_no_images(self):
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'],0)
+        self.assertEqual(response_dict['images'],[])
+
+    def test_api_v0_single_image(self):
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list,list)
+        self.assertEqual(response_list,[])
+
+        expected_title = "Test image"
+        image = Image.objects.create(
+            title=expected_title,
+            file=get_test_image_file(),
+        )
+
+        response = self.client.get('/api/v0/images/')
+        self.assertEqual(response.status_code, 200)
+        response_list = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_list,list)
+        returned_title = response_list[0]['title']
+        self.assertEqual(expected_title,returned_title)
+        returned_file_url = response_list[0]['file']
+        expected_file_name = image.file.name
+        self.assertIn(expected_file_name,returned_file_url)
+
+    def test_api_v1_single_image(self):
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'],0)
+        self.assertEqual(response_dict['images'],[])
+
+        expected_title = "Test image"
+        image = Image.objects.create(
+            title=expected_title,
+            file=get_test_image_file(),
+        )
+
+        response = self.client.get('/api/v1/images/')
+        self.assertEqual(response.status_code, 200)
+        response_dict = eval(response.content.decode(response.charset))
+        self.assertIsInstance(response_dict, dict)
+        self.assertEqual(response_dict['meta']['total_count'],1)
+        returned_title = response_dict['images'][0]['title']
+        self.assertEqual(expected_title,returned_title)
+       
 
 class AdminPages(TestCase, WagtailTestUtils):
 


### PR DESCRIPTION
Returns uploaded file paths along with other fields. Note that v1 api is still available. 

## Original 

![api_v1](https://cloud.githubusercontent.com/assets/2857670/11853383/40f5262e-a403-11e5-8408-eda6875830c9.png)

## New

![api_v0](https://cloud.githubusercontent.com/assets/2857670/11853381/3f4df436-a403-11e5-9d10-a7c10ca4d4a1.png)
